### PR TITLE
Handle static files with query strings and allow initial password setup

### DIFF
--- a/db.json
+++ b/db.json
@@ -2,12 +2,12 @@
   "users": [
     {
       "username": "admin",
-      "passwordHash": "99b3e4e158c91d2bac6d2a25a6380fe1:ef29ecf85df8e16f46a9b38cdc3f2ebb211cc6f62b57608d4a049be643444929c6e1d59ccb1aeb2b5e0d71445355a4d27dcf8f76283d38ba55d3fc7041db2477",
+      "passwordHash": null,
       "role": "admin"
     },
     {
       "username": "player1",
-      "passwordHash": "3ea700e5188ce39daa0b612151015f6a:faeaeae8f4c18ec1519efcb91dae31ac274b327dacb173c4504c4dd482cd82acb384b066293332b2add4720f3a9406d3fa7d95ec52b1c4b3f511d2379fe6bc0d",
+      "passwordHash": null,
       "role": "player"
     }
   ],

--- a/server.js
+++ b/server.js
@@ -98,7 +98,9 @@ function requireAuth(req, res, role) {
 
 // Serve static files from the public directory
 function serveStatic(req, res) {
-  const filePath = path.join(__dirname, 'public', decodeURIComponent(req.url.replace(/^\/public\//, '')));
+  const url = new URL(req.url, 'http://localhost');
+  const pathname = decodeURIComponent(url.pathname.replace(/^\/public\//, ''));
+  const filePath = path.join(__dirname, 'public', pathname);
   if (!filePath.startsWith(path.join(__dirname, 'public'))) {
     res.writeHead(400);
     res.end('Bad request');
@@ -650,3 +652,5 @@ const port = process.env.PORT || 3000;
 server.listen(port, () => {
   console.log(`Server running on http://localhost:${port}`);
 });
+
+module.exports = server;

--- a/server.test.js
+++ b/server.test.js
@@ -1,3 +1,80 @@
-test('hello world!', () => {
-	expect(1 + 1).toBe(2);
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+let server;
+let port;
+let dbBackup;
+
+beforeAll(done => {
+  dbBackup = fs.readFileSync(path.join(__dirname, 'db.json'), 'utf8');
+  process.env.PORT = '0';
+  server = require('./server');
+  server.on('listening', () => {
+    port = server.address().port;
+    done();
+  });
+});
+
+afterAll(done => {
+  fs.writeFileSync(path.join(__dirname, 'db.json'), dbBackup);
+  server.close(done);
+});
+
+test('serves static file when query string present', done => {
+  const expected = fs.readFileSync(path.join(__dirname, 'public', 'character.html'), 'utf8');
+  http.get(`http://localhost:${port}/public/character.html?id=123`, res => {
+    let data = '';
+    res.on('data', chunk => {
+      data += chunk;
+    });
+    res.on('end', () => {
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toBe('text/html');
+      expect(data).toBe(expected);
+      done();
+    });
+  });
+});
+
+test('allows setting password on first login', done => {
+  const postData = JSON.stringify({ username: 'admin', password: 'newpass' });
+
+  const req = http.request({
+    method: 'POST',
+    hostname: 'localhost',
+    port,
+    path: '/api/login',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(postData)
+    }
+  }, res => {
+    res.on('data', () => {});
+    res.on('end', () => {
+      expect(res.statusCode).toBe(200);
+
+      const req2 = http.request({
+        method: 'POST',
+        hostname: 'localhost',
+        port,
+        path: '/api/login',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(postData)
+        }
+      }, res2 => {
+        res2.on('data', () => {});
+        res2.on('end', () => {
+          expect(res2.statusCode).toBe(200);
+          done();
+        });
+      });
+      req2.write(postData);
+      req2.end();
+    });
+  });
+  req.on('error', done);
+  req.write(postData);
+  req.end();
 });


### PR DESCRIPTION
## Summary
- sanitize static file paths by stripping query strings before lookup and MIME detection
- initialize default admin and player users with null passwords and set on first login
- add tests covering static files with query strings and initial password creation

## Testing
- `./node_modules/.bin/jest`


------
https://chatgpt.com/codex/tasks/task_e_68aa6da481f08333aa91677031e59153